### PR TITLE
Tweak fuzzy params. Fixes #1.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,16 +55,18 @@ class Body extends Component {
 		this.options = {
 			keys: [{
 					name: 'tags',
-					weight: 0.65
+					weight: 0.5
 				},{
 					name: 'title',
-					weight: 0.2
+					weight: 0.3
 				},{
 					name: 'description',
-					weight: 0.15
+					weight: 0.2
 				}],
 			shouldSort: true,
-			minMatchCharLength: 0,
+			tokenize: true,
+			threshold: 0.3,
+			minMatchCharLength: 1,
 		};
 	}
 


### PR DESCRIPTION
- Reweight keys to give description more ability to make a card appear
- Add min match length to reduce extenuaous results
- Reduce threshold to reduce extenuaous results